### PR TITLE
feat: redirect all non-homepage requests to short url service

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,5 +9,11 @@
         }
       ]
     }
+  ],
+  "redirects": [
+    {
+      "source": "/:path",
+      "destination": "https://codfi.sh/:path"
+    }
   ]
 }


### PR DESCRIPTION
trying to get all NON `/` requests to redirect to `codfi.sh/` ... 